### PR TITLE
correct the path to haproxy - should be /usr/sbin/haproxy

### DIFF
--- a/assets/scripts/swarm.py
+++ b/assets/scripts/swarm.py
@@ -10,13 +10,9 @@ result = {
 }
 
 if os.getenv("HAPROXY_PASSWORD"):
-    password = os.getenv("HAPROXY_PASSWORD")
-    if password.startswith("/run/secrets/"): # support docker secrets
-        with open(password) as passfh:
-            password = passfh.read().strip()
     result["stats"] = {
         "username": os.getenv("HAPROXY_USERNAME") if os.getenv("HAPROXY_USERNAME") else "admin",
-        "password": password,
+        "password": os.getenv("HAPROXY_PASSWORD"),
         "port": os.getenv("HAPROXY_STATS_PORT") if os.getenv("HAPROXY_STATS_PORT") else "1936",
     }
 


### PR DESCRIPTION
The script `assets/scripts/haproxy-reload.sh` had the incorrect path to haproxy: `/usr/local/sbin/haproxy` but in fact haproxy is located at `/usr/sbin/haproxy` in the container. As a result of the incorrect path, haproxy was not being reloaded when a new stack was added or an existing one was removed. 

(An unrelated note - it looks like the docker image at `byjg/easy-haproxy` is not built from the current Dockerfile in this repository. That container does not start supervisord or cron, so when you run it, it does not detect new services coming up or going down). 
