### PR TITLE
support multi containers

### DIFF
--- a/easymapping/__init__.py
+++ b/easymapping/__init__.py
@@ -45,7 +45,11 @@ class HaproxyConfigGenerator:
         # static?
         if len(lineList) > 0:
             self.mapping["easymapping"] = self.__parse(lineList)
-
+        else:
+            for d in self.mapping["easymapping"]:
+                for name, hosts in d.get('hosts', {}).items():
+                    if type(hosts) != list:
+                        d['hosts'][name] = [hosts]
         # still 'None' -> default to [] for jinja2
         if self.mapping["easymapping"] is None:
             self.mapping["easymapping"] = []
@@ -119,7 +123,8 @@ class HaproxyConfigGenerator:
                     ""
                 )
 
-                easymapping[key]["hosts"][d[host_label]] = "{}:{}".format(container, ct_port)
+                easymapping[key]["hosts"].setdefault(d[host_label], [])
+                easymapping[key]["hosts"][d[host_label]] += ["{}:{}".format(container, ct_port)]
 
                 # handle SSL
                 ssl_label = self.label.create(["sslcert", definition])

--- a/examples/docker/docker-compose-multi-containers.yml
+++ b/examples/docker/docker-compose-multi-containers.yml
@@ -1,0 +1,38 @@
+version: "3"
+
+services:
+  haproxy:
+    image: 0x0400/easy-haproxy
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      DISCOVER: docker
+      HAPROXY_CUSTOMERRORS: "true"
+      HAPROXY_USERNAME: admin
+      HAPROXY_PASSWORD: password
+      HAPROXY_STATS_PORT: 1936
+    ports:
+        - 19901:19901
+
+
+  nginx:
+      #image: nginx
+    image: stenote/nginx-hostname
+    deploy:
+        replicas: 2
+    labels:
+      easyhaproxy.definitions: "http"
+
+      easyhaproxy.redirect.http: google.helloworld.com--www.google.com
+      easyhaproxy.host.http: www.helloworld.com
+      easyhaproxy.port.http: 19901
+      easyhaproxy.localport.http: 80
+
+# curl -H Host:www.helloworld.com localhost:19901
+# f6d8d45b7411
+# 59b213cb8592
+
+# curl -I -H Host:google.helloworld.com localhost:19901
+# HTTP/1.1 301 Moved Permanently
+# content-length: 0
+# location: www.google.com/

--- a/templates/haproxy.cfg.j2
+++ b/templates/haproxy.cfg.j2
@@ -62,6 +62,8 @@ backend srv_{{ host }}
     option tcp-check
     tcp-check connect{{ " ssl" if o["health-check"] == "ssl" }}
         {% endif %}
-    server srv {{ o["hosts"][k] }} check weight 1{{ " verify none" if o["health-check"] == "ssl" }}
+        {% for c in o["hosts"][k] %}
+    server srv-{{ loop.index0 }} {{ c }} check weight 1{{ " verify none" if o["health-check"] == "ssl" }}
+        {% endfor %}
     {% endfor %}
 {% endfor %}

--- a/tests/expected/services-tcp.txt
+++ b/tests/expected/services-tcp.txt
@@ -23,4 +23,4 @@ backend srv_agent_quantum_local_31339_1
     mode tcp
     option tcp-check
     tcp-check connect ssl
-    server srv test_agent:9001 check weight 1 verify none
+    server srv-0 test_agent:9001 check weight 1 verify none

--- a/tests/expected/services.txt
+++ b/tests/expected/services.txt
@@ -23,7 +23,7 @@ backend srv_agent_quantum_example_org_31339_1
     mode tcp
     option tcp-check
     tcp-check connect
-    server srv my-stack_agent:9001 check weight 1
+    server srv-0 my-stack_agent:9001 check weight 1
 
 frontend http_in_31337_2
     bind *:31337
@@ -43,14 +43,14 @@ backend srv_cadvisor_quantum_example_org_31337_2
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv my-stack_cadvisor:8080 check weight 1
+    server srv-0 my-stack_cadvisor:8080 check weight 1
 backend srv_node-exporter_quantum_example_org_31337_2
     balance roundrobin
     mode http
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv my-stack_node-exporter:9100 check weight 1
+    server srv-0 my-stack_node-exporter:9100 check weight 1
 
 frontend http_in_80_3
     bind *:80
@@ -71,7 +71,7 @@ backend srv_www_somehost_com_br_80_3
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv some-service:80 check weight 1
+    server srv-0 some-service:80 check weight 1
 
 frontend http_in_443_4
     bind *:443  ssl crt /tmp/www.somehost.com.br.1.pem
@@ -92,4 +92,4 @@ backend srv_www_somehost_com_br_443_4
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv some-service:80 check weight 1
+    server srv-0 some-service:80 check weight 1

--- a/tests/expected/static.txt
+++ b/tests/expected/static.txt
@@ -53,14 +53,14 @@ backend srv_host1_com_br_80_1
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv container:5000 check weight 1
+    server srv-0 container:5000 check weight 1
 backend srv_host2_com_br_80_1
     balance roundrobin
     mode http
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv other:3000 check weight 1
+    server srv-0 other:3000 check weight 1
 
 frontend http_in_443_2
     bind *:443  ssl crt /etc/haproxy/certs/mycert.pem
@@ -76,7 +76,7 @@ backend srv_host1_com_br_443_2
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv container:80 check weight 1
+    server srv-0 container:80 check weight 1
 
 frontend http_in_8080_3
     bind *:8080
@@ -92,4 +92,4 @@ backend srv_host3_com_br_8080_3
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
-    server srv domain:8181 check weight 1
+    server srv-0 domain:8181 check weight 1


### PR DESCRIPTION
support multi containers like this
```

frontend http_in_80_1
    bind *:80
    mode http

    acl is_rule_localhost_80_1_1 hdr(host) -i localhost
    acl is_rule_localhost_80_1_2 hdr(host) -i localhost:80
    use_backend srv_localhost_80_1 if is_rule_localhost_80_1_1 OR is_rule_localhost_80_1_2

backend srv_localhost_80_1
    balance roundrobin
    mode http
    option forwardfor
    http-request set-header X-Forwarded-Port %[dst_port]
    http-request add-header X-Forwarded-Proto https if { ssl_fc }
    server a0b8ccb2d40f:80 a0b8ccb2d40f:80 check weight 1
    server f718c6f0f6c3:80 f718c6f0f6c3:80 check weight 1



```